### PR TITLE
init with "npm run -d $NPM_RUN" (w/ default value: "start")

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -10,6 +10,7 @@ EXPOSE 8080
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
 # available on the CLI without using npm's --global installation mode
 ENV NODEJS_VERSION=0.10 \
+    NPM_RUN=start \
     PATH=$HOME/node_modules/.bin/:$PATH
 
 LABEL io.k8s.description="Platform for building and running Node.js 0.10 applications" \

--- a/0.10/Dockerfile.rhel7
+++ b/0.10/Dockerfile.rhel7
@@ -8,6 +8,7 @@ EXPOSE 8080
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
 # available on the CLI without using npm's --global installation mode
 ENV NODEJS_VERSION=0.10 \
+    NPM_RUN=start \
     PATH=$HOME/node_modules/.bin/:$PATH
 
 LABEL summary="Platform for building and running Node.js 0.10 applications" \

--- a/0.10/README.md
+++ b/0.10/README.md
@@ -85,12 +85,23 @@ Repository organization
 Environment variables
 ---------------------
 
-To set environment variables, you can place them as a key value pair into a `.sti/environment`
-file inside your source code repository.
+Application developers can use the following environment variables to configure the runtime behavior of this image:
+
+NAME        | Description
+------------|-------------
+NODE_ENV    | NodeJS runtime mode (default: "production")
+DEV_MODE    | When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
+NPM_RUN     | Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+HTTP_PROXY  | use an npm proxy during assembly
+HTTPS_PROXY | use an npm proxy during assembly
+
+One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser
 
-Setting the HTTP_PROXY or HTTPS_PROXY environment variable will set the appropriate npm proxy configuration during assembly.
+#### NOTE: Define your own "`DEV_MODE`":
+
+The following `package.json` example includes a `scripts.dev` entry.  You can define your own custom [`NPM_RUN`](https://docs.npmjs.com/cli/run-script) scripts in your application's `package.json` file.
 
 Development Mode
 ---------------------

--- a/0.10/s2i/bin/run
+++ b/0.10/s2i/bin/run
@@ -11,7 +11,7 @@ run_node() {
     exec nodemon --debug="$DEBUG_PORT"
   else
     echo "Launching via npm..."
-    exec npm start -d
+    exec npm run -d $NPM_RUN
   fi
 } 
 


### PR DESCRIPTION
Allow Env control over which script to init with using the `$NPM_RUN` variable