### PR TITLE
bzip2 is a dependency for installing patternfly, phantomjs

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -21,7 +21,7 @@ LABEL io.k8s.description="Platform for building and running Node.js 0.10 applica
       com.redhat.dev-mode.port="DEBUG_PORT:5858"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="nodejs010" && \
+    INSTALL_PKGS="nodejs010 bzip2" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y


### PR DESCRIPTION
see https://github.com/ryanj/origin-s2i-nodejs/issues/8