### PR TITLE
Install nodemon from SCL

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -22,7 +22,7 @@ LABEL io.k8s.description="Platform for building and running Node.js 0.10 applica
       com.redhat.dev-mode.port="DEBUG_PORT:5858"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="nodejs010 bzip2 nss_wrapper" && \
+    INSTALL_PKGS="nodejs010 nodejs010-nodejs-nodemon bzip2 nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y

--- a/0.10/Dockerfile.rhel7
+++ b/0.10/Dockerfile.rhel7
@@ -30,8 +30,7 @@ LABEL com.redhat.component="nodejs010" \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="nodejs010 nodejs-nodemon bzip2 nss_wrapper" && \
-    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
+    INSTALL_PKGS="nodejs010 nodejs010-nodejs-nodemon bzip2 nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y


### PR DESCRIPTION
No need to create symlink either, since nodemon is installed into
/opt/rh/nodejs010/root/usr/bin/nodemon and nodejs010 is enabled.
We also have nodemon in centos already.